### PR TITLE
Fixed function parameter

### DIFF
--- a/as/NFT/assembly/index.ts
+++ b/as/NFT/assembly/index.ts
@@ -142,15 +142,13 @@ export function nft_tokens_for_owner(
     }
     const media = accountMedia.values()
 
-    logging.log(media.length)
-
     let tokens: Array<Media> = []
 
     if (limit == 0) {
         limit = <u8>media.length
     }
 
-    for (let i = parseInt(from_index); i < limit; i++) {
+    for (let i = parseInt(from_index); i < (parseInt(from_index)+limit); i++) {
         let token = media.at(<i32>i)
         const design = designs.getSome(token)
         design.metadata = nft_token_metadata(token)


### PR DESCRIPTION
## Problem

`not_tokens_for_owner` method is not returning anything when called it for 2nd time. It was happening earlier because value of `limit`parameter used as the upper bound of the for loop. Therefore, when it is calling for 2nd time, it is always below the limit. So it is not returning anything.

## Solution

Added `from_index  + limit` as the upper bound. So from_index is always below the upper bound.
