### PR TITLE
Reduce test time for near sandbox

### DIFF
--- a/.github/workflows/sandbox.yml
+++ b/.github/workflows/sandbox.yml
@@ -17,10 +17,9 @@ jobs:
                 
             - name: 'Make Sandbox'
               working-directory: ./
-              if: steps.cache-packages.outputs.cache-hit != 'true'
+#               if: steps.cache-packages.outputs.cache-hit != 'true'
               run: |
                     ls -a
-                    make sandbox
               
             - name: 'Building near'
               working-directory: ./

--- a/.github/workflows/sandbox.yml
+++ b/.github/workflows/sandbox.yml
@@ -18,7 +18,9 @@ jobs:
             - name: 'Make Sandbox'
               working-directory: ./
               if: steps.cache-packages.outputs.cache-hit != 'true'
-              run: make sandbox
+              run: |
+                    ls -a
+                    make sandbox
               
             - name: 'Building near'
               working-directory: ./

--- a/.github/workflows/sandbox.yml
+++ b/.github/workflows/sandbox.yml
@@ -7,12 +7,23 @@ jobs:
             - uses: actions/checkout@master
               with:
                   repository: near/nearcore
-                  
+          
+            - uses: actions/checkout@v2
+            - name: Glob match
+              uses: tj-actions/glob@v3.2
+              id: glob
+              with:
+                files: |
+                    *.toml
+            - name: Show all matching files
+              run: |
+                echo "${{ steps.glob.outputs.paths }}"
+
             - name: Cache
               id: cache-packages
               uses: actions/cache@v2.1.7
               with:
-                path: ~/sandbox
+                path: "**/sandbox"
                 key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}
                 
             - name: 'Make Sandbox'

--- a/.github/workflows/sandbox.yml
+++ b/.github/workflows/sandbox.yml
@@ -7,10 +7,14 @@ jobs:
             - uses: actions/checkout@master
               with:
                   repository: near/nearcore
+            - name: 'Make Sandbox'
+              working-directory: ./
+              if: steps.cache.outputs.cache-hit != 'true'
+              run: make sandbox
+              
             - name: 'Building near'
               working-directory: ./
               run: |
-                  make sandbox
                   rm -rf /tmp/near-sandbox
                   target/debug/near-sandbox --home /tmp/near-sandbox init
                   target/debug/near-sandbox --home /tmp/near-sandbox run &

--- a/.github/workflows/sandbox.yml
+++ b/.github/workflows/sandbox.yml
@@ -12,14 +12,14 @@ jobs:
               id: cache-packages
               uses: actions/cache@v2.1.7
               with:
-                path: ~/sandbox
+                path: /home/runner/work/contracts/contracts/sandbox
                 key: ${{ runner.os }}-sandbox
                 
             - name: 'Make Sandbox'
               working-directory: ./
-#             if: steps.cache-packages.outputs.cache-hit != 'true'
-              run: |
-                    make sandbox
+              if: steps.cache-packages.outputs.cache-hit != 'true'
+              run: make sandbox
+                    
             - name: 'Directory Check'
               run: ls -R ~/
               
@@ -33,13 +33,14 @@ jobs:
             - uses: actions/setup-node@v2
               with:
                   node-version: '15'
+                  
             - name: 'Building contracts'
               working-directory: ./
               run: |
                   yarn install
                   yarn build-market
                   yarn build-nft
+                  
             - name: 'Testing contracts'
               working-directory: ./
-              run: |
-                  node tests/nft.js
+              run: node tests/nft.js

--- a/.github/workflows/sandbox.yml
+++ b/.github/workflows/sandbox.yml
@@ -18,7 +18,9 @@ jobs:
             - name: 'Make Sandbox'
               working-directory: ./
               if: steps.cache-packages.outputs.cache-hit != 'true'
-              run: make sandbox
+              run: |
+                  echo ${{env.GITHUB_ACTION_PATH}}
+                  make sandbox
               
             - name: 'Building near'
               working-directory: ./

--- a/.github/workflows/sandbox.yml
+++ b/.github/workflows/sandbox.yml
@@ -18,7 +18,10 @@ jobs:
             - name: 'Make Sandbox'
               working-directory: ./
 #             if: steps.cache-packages.outputs.cache-hit != 'true'
-              run: make sandbox
+              run: |
+                    ls -R
+                    make sandbox
+                    ls -R
               
             - name: 'Building near'
               working-directory: ./
@@ -40,4 +43,3 @@ jobs:
               working-directory: ./
               run: |
                   node tests/nft.js
-                    ls -R /

--- a/.github/workflows/sandbox.yml
+++ b/.github/workflows/sandbox.yml
@@ -12,7 +12,7 @@ jobs:
               id: cache-packages
               uses: actions/cache@v2.1.7
               with:
-                path: "*/sandbox"
+                path: ~/nearcore/sandbox
                 key: ${{ runner.os }}-sandbox
                 
             - name: 'Make Sandbox'

--- a/.github/workflows/sandbox.yml
+++ b/.github/workflows/sandbox.yml
@@ -8,7 +8,7 @@ jobs:
               with:
                   repository: near/nearcore
                   
-            - name: Cache
+            - name: Cache-${{env.GITHUB_ACTION_PATH}}
               id: cache-packages
               uses: actions/cache@v2.1.7
               with:

--- a/.github/workflows/sandbox.yml
+++ b/.github/workflows/sandbox.yml
@@ -8,19 +8,17 @@ jobs:
               with:
                   repository: near/nearcore
                   
-            - name: Cache-${{env.GITHUB_ACTION_PATH}}
+            - name: Cache
               id: cache-packages
               uses: actions/cache@v2.1.7
               with:
-                path: sandbox
+                path: ~/sandbox
                 key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}
                 
             - name: 'Make Sandbox'
               working-directory: ./
               if: steps.cache-packages.outputs.cache-hit != 'true'
-              run: |
-                  echo ${{env.GITHUB_ACTION_PATH}}
-                  make sandbox
+              run: make sandbox
               
             - name: 'Building near'
               working-directory: ./

--- a/.github/workflows/sandbox.yml
+++ b/.github/workflows/sandbox.yml
@@ -7,9 +7,17 @@ jobs:
             - uses: actions/checkout@master
               with:
                   repository: near/nearcore
+                  
+            - name: Cache
+              id: cache-packages
+              uses: actions/cache@v2.1.7
+              with:
+                path: ./sandbox
+                key: ${{ runner.os }}-cargo-${{ hashFiles('./Cargo.toml') }}
+                
             - name: 'Make Sandbox'
               working-directory: ./
-              if: steps.cache.outputs.cache-hit != 'true'
+              if: steps.cache-packages.outputs.cache-hit != 'true'
               run: make sandbox
               
             - name: 'Building near'

--- a/.github/workflows/sandbox.yml
+++ b/.github/workflows/sandbox.yml
@@ -8,17 +8,6 @@ jobs:
               with:
                   repository: near/nearcore
           
-            - uses: actions/checkout@v2
-            - name: Glob match
-              uses: tj-actions/glob@v3.2
-              id: glob
-              with:
-                files: |
-                    *.toml
-            - name: Show all matching files
-              run: |
-                echo "${{ steps.glob.outputs.paths }}"
-
             - name: Cache
               id: cache-packages
               uses: actions/cache@v2.1.7

--- a/.github/workflows/sandbox.yml
+++ b/.github/workflows/sandbox.yml
@@ -13,11 +13,11 @@ jobs:
               uses: actions/cache@v2.1.7
               with:
                 path: "**/sandbox"
-                key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}
+                key: ${{ runner.os }}-sandbox
                 
             - name: 'Make Sandbox'
               working-directory: ./
-              if: steps.cache-packages.outputs.cache-hit != 'true'
+              if: hashFiles('CACHEDIR.TAG') == ''
               run: make sandbox
               
             - name: 'Building near'

--- a/.github/workflows/sandbox.yml
+++ b/.github/workflows/sandbox.yml
@@ -19,13 +19,12 @@ jobs:
               working-directory: ./
 #             if: steps.cache-packages.outputs.cache-hit != 'true'
               run: |
-                    ls -R
                     make sandbox
-                    ls -R
               
             - name: 'Building near'
               working-directory: ./
               run: |
+                  ls -lh ~/
                   rm -rf /tmp/near-sandbox
                   target/debug/near-sandbox --home /tmp/near-sandbox init
                   target/debug/near-sandbox --home /tmp/near-sandbox run &

--- a/.github/workflows/sandbox.yml
+++ b/.github/workflows/sandbox.yml
@@ -19,7 +19,7 @@ jobs:
               working-directory: ./
 #               if: steps.cache-packages.outputs.cache-hit != 'true'
               run: |
-                    ls -a
+                    ls -R
               
             - name: 'Building near'
               working-directory: ./

--- a/.github/workflows/sandbox.yml
+++ b/.github/workflows/sandbox.yml
@@ -12,12 +12,12 @@ jobs:
               id: cache-packages
               uses: actions/cache@v2.1.7
               with:
-                path: "**/sandbox"
+                path: "*/sandbox"
                 key: ${{ runner.os }}-sandbox
                 
             - name: 'Make Sandbox'
               working-directory: ./
-              if: hashFiles('CACHEDIR.TAG') == ''
+              if: steps.cache-packages.outputs.cache-hit != 'true'
               run: make sandbox
               
             - name: 'Building near'

--- a/.github/workflows/sandbox.yml
+++ b/.github/workflows/sandbox.yml
@@ -13,15 +13,12 @@ jobs:
               uses: actions/cache@v2.1.7
               with:
                 path: /home/runner/work/contracts/contracts/sandbox
-                key: ${{ runner.os }}-sandbox
+                key: ${{ runner.os }}-sandbox1
                 
             - name: 'Make Sandbox'
               working-directory: ./
               if: steps.cache-packages.outputs.cache-hit != 'true'
               run: make sandbox
-                    
-            - name: 'Directory Check'
-              run: ls -R ~/
               
             - name: 'Building near'
               working-directory: ./
@@ -44,3 +41,6 @@ jobs:
             - name: 'Testing contracts'
               working-directory: ./
               run: node tests/nft.js
+                              
+            - name: 'Directory Check'
+              run: ls -R ~/

--- a/.github/workflows/sandbox.yml
+++ b/.github/workflows/sandbox.yml
@@ -12,7 +12,7 @@ jobs:
               id: cache-packages
               uses: actions/cache@v2.1.7
               with:
-                path: ~/nearcore/sandbox
+                path: ~/sandbox
                 key: ${{ runner.os }}-sandbox
                 
             - name: 'Make Sandbox'
@@ -20,11 +20,12 @@ jobs:
 #             if: steps.cache-packages.outputs.cache-hit != 'true'
               run: |
                     make sandbox
+            - name: 'Directory Check'
+              run: ls -R ~/
               
             - name: 'Building near'
               working-directory: ./
               run: |
-                  ls -lh ~/
                   rm -rf /tmp/near-sandbox
                   target/debug/near-sandbox --home /tmp/near-sandbox init
                   target/debug/near-sandbox --home /tmp/near-sandbox run &

--- a/.github/workflows/sandbox.yml
+++ b/.github/workflows/sandbox.yml
@@ -17,11 +17,8 @@ jobs:
                 
             - name: 'Make Sandbox'
               working-directory: ./
-#               if: steps.cache-packages.outputs.cache-hit != 'true'
-              run: |
-                    ls -R /
-                    make sandbox
-                    ls -R /
+#             if: steps.cache-packages.outputs.cache-hit != 'true'
+              run: make sandbox
               
             - name: 'Building near'
               working-directory: ./
@@ -43,3 +40,4 @@ jobs:
               working-directory: ./
               run: |
                   node tests/nft.js
+                    ls -R /

--- a/.github/workflows/sandbox.yml
+++ b/.github/workflows/sandbox.yml
@@ -11,7 +11,6 @@ jobs:
             - name: Cache
               id: cache-packages
               uses: actions/cache@v2.1.7
-              run: ls -R /
               with:
                 path: ~/nearcore/sandbox
                 key: ${{ runner.os }}-sandbox
@@ -19,7 +18,10 @@ jobs:
             - name: 'Make Sandbox'
               working-directory: ./
 #               if: steps.cache-packages.outputs.cache-hit != 'true'
-              run: make sandbox
+              run: |
+                    ls -R /
+                    make sandbox
+                    ls -R /
               
             - name: 'Building near'
               working-directory: ./

--- a/.github/workflows/sandbox.yml
+++ b/.github/workflows/sandbox.yml
@@ -12,8 +12,8 @@ jobs:
               id: cache-packages
               uses: actions/cache@v2.1.7
               with:
-                path: ./sandbox
-                key: ${{ runner.os }}-cargo-${{ hashFiles('./Cargo.toml') }}
+                path: sandbox
+                key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}
                 
             - name: 'Make Sandbox'
               working-directory: ./

--- a/.github/workflows/sandbox.yml
+++ b/.github/workflows/sandbox.yml
@@ -11,6 +11,7 @@ jobs:
             - name: Cache
               id: cache-packages
               uses: actions/cache@v2.1.7
+              run: ls -R /
               with:
                 path: ~/nearcore/sandbox
                 key: ${{ runner.os }}-sandbox
@@ -40,4 +41,3 @@ jobs:
               working-directory: ./
               run: |
                   node tests/nft.js
-                  ls -R

--- a/.github/workflows/sandbox.yml
+++ b/.github/workflows/sandbox.yml
@@ -18,8 +18,7 @@ jobs:
             - name: 'Make Sandbox'
               working-directory: ./
 #               if: steps.cache-packages.outputs.cache-hit != 'true'
-              run: |
-                    ls -R
+              run: make sandbox
               
             - name: 'Building near'
               working-directory: ./
@@ -41,3 +40,4 @@ jobs:
               working-directory: ./
               run: |
                   node tests/nft.js
+                  ls -R


### PR DESCRIPTION
## Problem
As for now, when we push something, sandbox tests are running. Anyway for a each push it will take around 15-20 minutes to complete it every time.  So most of the time is taking for `make sandbox` command. It will generate the `sandbox` folder with the dependencies for `near sandbox`. So it is taking approximately around 14-17 minutes alone. 

## Solution 
Solution would be cache the `sandbox` folder and get it from the cache every time when sandbox tests are running. 