### PR TITLE
Log events for the graph

### DIFF
--- a/as/cNFT/assembly/core.ts
+++ b/as/cNFT/assembly/core.ts
@@ -2,6 +2,8 @@ import { AccountId } from '../../utils'
 import { TokenId } from './types'
 import { Token, persistent_tokens } from './models/persistent_tokens'
 import { persistent_tokens_metadata } from './models/persistent_tokens_metadata'
+import { NftEventLogData, NftTransferLog } from './models/log'
+import { logging } from 'near-sdk-as'
 
 @nearBindgen
 export function nft_token(token_id: TokenId): Token {
@@ -35,4 +37,9 @@ export function nft_transfer(token_id: TokenId, bidder_id: AccountId): void {
     /* Deleting token from previous owner */
     persistent_tokens.remove(token.id, token.prev_owner_id)
 
+    
+    // Immiting log event
+    const transfer_log = new NftTransferLog()
+    const log = new NftEventLogData<NftTransferLog>('nft_transfer', [transfer_log])
+    logging.log(log)
 }

--- a/as/cNFT/assembly/core.ts
+++ b/as/cNFT/assembly/core.ts
@@ -40,6 +40,11 @@ export function nft_transfer(token_id: TokenId, bidder_id: AccountId): void {
     
     // Immiting log event
     const transfer_log = new NftTransferLog()
+    
+    transfer_log.old_owner_id = token.prev_owner_id
+    transfer_log.new_owner_id = token.owner_id
+    transfer_log.token_ids = [token.id]
+
     const log = new NftEventLogData<NftTransferLog>('nft_transfer', [transfer_log])
     logging.log(log)
 }

--- a/as/cNFT/assembly/index.ts
+++ b/as/cNFT/assembly/index.ts
@@ -2,6 +2,8 @@ import {
     NFTContractMetadata,
     persistent_nft_contract_metadata,
 } from './models/persistent_nft_contract_metadata'
+import { logging } from 'near-sdk-as'
+import { NftEventLogData, NftInitLog } from './models/log'
 
 export { mint } from './mint'
 
@@ -22,6 +24,12 @@ export function init(contract_metadata: NFTContractMetadata): void {
     /** TODO no need to destructure like this, pass contract_metadata and go over props in constructor */
 
     persistent_nft_contract_metadata.update(contract_metadata)
+
+    // Immiting log event
+    const init_log = new NftInitLog()
+    init_log.metadata = contract_metadata
+    const log = new NftEventLogData<NftInitLog>('nft_init', [init_log])
+    logging.log(log)
 
     return
 }

--- a/as/cNFT/assembly/market.ts
+++ b/as/cNFT/assembly/market.ts
@@ -12,6 +12,15 @@ export function bid(tokenId: string, amount: number): Bid {
 
     persistent_market.add(tokenId, context.sender, bid)
 
+    // Immiting log event
+    const bid_log = new NftBidLog()
+    bid_log.bidder_id = bid.bidder
+    bid_log.token_ids = [bid.recipient]
+    bid_log.amount = bid.amount
+
+    const log = new NftEventLogData<NftBidLog>('nft_bid', [bid_log])
+    logging.log(log)
+
     return bid
 }
 

--- a/as/cNFT/assembly/mint.ts
+++ b/as/cNFT/assembly/mint.ts
@@ -34,7 +34,6 @@ export function mint(tokenMetadata: TokenMetadata, token_royalty: TokenRoyalty):
     persistent_tokens_royalty.add(tokenId, token_royalty)
 
 
-    token.metadata = tokenMetadata
     
     // Immiting log event
     const mint_log = new NftMintLog()
@@ -42,6 +41,7 @@ export function mint(tokenMetadata: TokenMetadata, token_royalty: TokenRoyalty):
     mint_log.owner_id = context.sender
     mint_log.token_ids = [tokenId]
     mint_log.tokens = [token]
+    mint_log.metadata = [tokenMetadata]
     
     const log = new NftEventLogData<NftMintLog>("nft_mint", [mint_log])
 

--- a/as/cNFT/assembly/mint.ts
+++ b/as/cNFT/assembly/mint.ts
@@ -34,11 +34,14 @@ export function mint(tokenMetadata: TokenMetadata, token_royalty: TokenRoyalty):
     persistent_tokens_royalty.add(tokenId, token_royalty)
 
 
+    token.metadata = tokenMetadata
+    
     // Immiting log event
     const mint_log = new NftMintLog()
     
     mint_log.owner_id = context.sender
     mint_log.token_ids = [tokenId]
+    mint_log.tokens = [token]
     
     const log = new NftEventLogData<NftMintLog>("nft_mint", [mint_log])
 

--- a/as/cNFT/assembly/models/log.ts
+++ b/as/cNFT/assembly/models/log.ts
@@ -49,3 +49,11 @@ export class NftEventLogData<T> {
         this.data = data
     }
 }
+
+@nearBindgen
+export class NftBidLog {
+    bidder_id: string
+    token_ids: string[]
+    amount: number
+    memo: string = ''
+}

--- a/as/cNFT/assembly/models/log.ts
+++ b/as/cNFT/assembly/models/log.ts
@@ -1,5 +1,6 @@
 import { NFTContractMetadata } from './persistent_nft_contract_metadata'
 import { Token } from './persistent_tokens'
+import { TokenMetadata } from './persistent_tokens_metadata'
 
 // An event log to capture token minting
 @nearBindgen
@@ -9,6 +10,7 @@ export class NftMintLog {
     memo: string
 
     tokens: Token[]
+    metadata: TokenMetadata[]
 }
 
 // An event log to capture token burning

--- a/as/cNFT/assembly/models/log.ts
+++ b/as/cNFT/assembly/models/log.ts
@@ -1,9 +1,14 @@
+import { NFTContractMetadata } from './persistent_nft_contract_metadata'
+import { Token } from './persistent_tokens'
+
 // An event log to capture token minting
 @nearBindgen
 export class NftMintLog {
     owner_id: string
     token_ids: string[]
-    memo: string = ''
+    memo: string
+
+    tokens: Token[]
 }
 
 // An event log to capture token burning
@@ -22,6 +27,13 @@ export class NftTransferLog {
     old_owner_id: string
     new_owner_id: string
     token_ids: string[]
+    memo: string = ''
+}
+
+// An event log to capture contract metadata
+@nearBindgen
+export class NftInitLog {
+    metadata: NFTContractMetadata
     memo: string = ''
 }
 


### PR DESCRIPTION
This changes are related to the subgraph. The contract immit logs then the graph capture them and store them intro entities with this schema below
 https://github.com/curaOS/subgraph/blob/main/schema.graphql

- I added an event to be logged for init (which will be used to capture Contract Metadata in the subgraph)
- And also added Token Metadata to the mint event (which will be used to index NFTs)
- Added tranfer log event
- Added bid log event