### PR TITLE
Fixed `view` method issue + `nft_contract_metadata` update issue

### DIFF
--- a/as/cNFT/assembly/index.ts
+++ b/as/cNFT/assembly/index.ts
@@ -1,6 +1,7 @@
 import {
-    NFTContractMetadata,
-    persistent_nft_contract_metadata,
+    defaultNFTContractMetadata,
+    NFTContractMetadata, PersistentNFTContractMetadata,
+
 } from './models/persistent_nft_contract_metadata'
 import { logging } from 'near-sdk-as'
 import { NftEventLogData, NftInitLog } from './models/log'
@@ -23,6 +24,7 @@ export { nft_metadata } from './metadata'
 export function init(contract_metadata: NFTContractMetadata): void {
     /** TODO no need to destructure like this, pass contract_metadata and go over props in constructor */
 
+    const persistent_nft_contract_metadata = new PersistentNFTContractMetadata(defaultNFTContractMetadata());
     persistent_nft_contract_metadata.update(contract_metadata)
 
     // Immiting log event

--- a/as/cNFT/assembly/index.ts
+++ b/as/cNFT/assembly/index.ts
@@ -1,7 +1,5 @@
 import {
-    defaultNFTContractMetadata,
     NFTContractMetadata, PersistentNFTContractMetadata,
-
 } from './models/persistent_nft_contract_metadata'
 import { logging } from 'near-sdk-as'
 import { NftEventLogData, NftInitLog } from './models/log'
@@ -24,7 +22,7 @@ export { nft_metadata } from './metadata'
 export function init(contract_metadata: NFTContractMetadata): void {
     /** TODO no need to destructure like this, pass contract_metadata and go over props in constructor */
 
-    const persistent_nft_contract_metadata = new PersistentNFTContractMetadata(defaultNFTContractMetadata());
+    const persistent_nft_contract_metadata = new PersistentNFTContractMetadata();
     persistent_nft_contract_metadata.update(contract_metadata)
 
     // Immiting log event

--- a/as/cNFT/assembly/models/persistent_nft_contract_metadata.ts
+++ b/as/cNFT/assembly/models/persistent_nft_contract_metadata.ts
@@ -62,5 +62,5 @@ export class PersistentNFTContractMetadata {
 
 /**
  * @todo not sure best approach is to create this before the init and update it later  */
-export const persistent_nft_contract_metadata =
-    new PersistentNFTContractMetadata(defaultNFTContractMetadata())
+// export const persistent_nft_contract_metadata =
+//     new PersistentNFTContractMetadata(defaultNFTContractMetadata())

--- a/as/cNFT/assembly/models/persistent_nft_contract_metadata.ts
+++ b/as/cNFT/assembly/models/persistent_nft_contract_metadata.ts
@@ -39,8 +39,7 @@ export function defaultNFTContractMetadata(): NFTContractMetadata {
 export class PersistentNFTContractMetadata {
     static STORAGE_KEY: string = 'nft_contract_metadata'
 
-    constructor(contract_metadata: NFTContractMetadata) {
-        this.set_storage(contract_metadata)
+    constructor() {
     }
 
     update(contract_metadata: NFTContractMetadata): void {
@@ -62,5 +61,3 @@ export class PersistentNFTContractMetadata {
 
 /**
  * @todo not sure best approach is to create this before the init and update it later  */
-// export const persistent_nft_contract_metadata =
-//     new PersistentNFTContractMetadata(defaultNFTContractMetadata())


### PR DESCRIPTION
Fixed `init` function not updating `nft_contract_metadata`.
Fixed `view` methods are recognising as `call` methods.