### PR TITLE
fix `accept_bid`

### DIFF
--- a/as/cNFT/assembly/market.ts
+++ b/as/cNFT/assembly/market.ts
@@ -2,12 +2,15 @@ import { context, ContractPromise, ContractPromiseBatch, ContractPromiseResult, 
 import { Bid, BidsByBidder } from './models/market'
 import { persistent_market } from './models/persistent_market'
 import { NftEventLogData, NftBidLog } from './models/log'
-import { nft_token, nft_transfer } from './core'
 import { nft_payout } from './royalty_payout'
 import { persistent_tokens_royalty } from './models/persistent_tokens_royalty'
 import { persistent_tokens } from './models/persistent_tokens'
 import { XCC_GAS } from '../../utils'
-import { NftTransferArgs } from './types'
+
+class NftTransferArgs {
+    token_id: string
+    bidder_id: string
+}
 
 @nearBindgen
 export function set_bid(tokenId: string, bid: Bid): Bid {

--- a/as/cNFT/assembly/royalty_payout.ts
+++ b/as/cNFT/assembly/royalty_payout.ts
@@ -4,6 +4,7 @@ import { persistent_tokens } from './models/persistent_tokens'
 import { persistent_tokens_royalty } from './models/persistent_tokens_royalty'
 import { Payout, TokenId } from './types'
 
+/** @todo add back @nearBindgen */
 export function nft_payout(
     token_id: TokenId,
     balance: u128

--- a/as/cNFT/assembly/royalty_payout.ts
+++ b/as/cNFT/assembly/royalty_payout.ts
@@ -4,7 +4,6 @@ import { persistent_tokens } from './models/persistent_tokens'
 import { persistent_tokens_royalty } from './models/persistent_tokens_royalty'
 import { Payout, TokenId } from './types'
 
-@nearBindgen
 export function nft_payout(
     token_id: TokenId,
     balance: u128

--- a/as/cNFT/assembly/types.d.ts
+++ b/as/cNFT/assembly/types.d.ts
@@ -7,8 +7,3 @@ export declare type Payout = Map<AccountId, u128>
 
 export declare type Amount = u128
 export declare type Balance = Amount
-
-export declare class NftTransferArgs {
-    token_id: string
-    bidder_id: string
-}

--- a/as/cNFT/assembly/types.d.ts
+++ b/as/cNFT/assembly/types.d.ts
@@ -7,3 +7,8 @@ export declare type Payout = Map<AccountId, u128>
 
 export declare type Amount = u128
 export declare type Balance = Amount
+
+export declare class NftTransferArgs {
+    token_id: string
+    bidder_id: string
+}


### PR DESCRIPTION
Previously `accept_bid` was calling methods from the same contract (nft_token, nft_payout, nft_transfer) which was causing building the contract to fail.

So the solution I did:
- nft_token: replaced `nft_token` with `persistent_tokens.get()`
- nft_payout: it wasn't exported from the contract anyway, so I removed `@nearBindgen` from it
- nft_transfer: Now is called as a Cross Contract Call