### PR TITLE
Add mint royalty and payout default

### DIFF
--- a/as/cNFT/assembly/__tests__/index.cnft.unit.spec.ts
+++ b/as/cNFT/assembly/__tests__/index.cnft.unit.spec.ts
@@ -1,6 +1,6 @@
 import { VMContext } from 'near-mock-vm'
 import { u128 } from 'near-sdk-as'
-import { defaultNFTContractMetadata, NFTContractExtra } from '../models/persistent_nft_contract_metadata'
+import { defaultNFTContractMetadata } from '../models/persistent_nft_contract_metadata'
 import { TokenMetadata } from '../models/persistent_tokens_metadata'
 import { TokenRoyalty } from '../models/persistent_tokens_royalty'
 import {
@@ -25,7 +25,6 @@ import { nft_payout } from '../royalty_payout'
 import { Bid } from '../models/market'
 import { ONE_NEAR } from '../../../utils'
 
-
 const initContract = (): void => {
     const nft_contract_metadata = defaultNFTContractMetadata()
 
@@ -45,13 +44,11 @@ const mintToken = (accountId: AccountId): Token => {
     token_royalty.percentage = 2500
     token_royalty.split_between.set('address', 2500)
 
-    const token = mint(token_metadata, token_royalty)
-    return token
+    return mint(token_metadata, token_royalty)
 }
 
 describe('- CONTRACT -', () => {
-
-    it('xxx returns token lenght', () => {        
+    it('xxx returns token length', () => {
         const nftTotalSupply = nft_total_supply()
 
         log(nftTotalSupply)
@@ -137,12 +134,12 @@ describe('- CONTRACT -', () => {
         mintToken('hello.testnet')
         const token = mintToken('hello.testnet')
 
-        burn_design(token.id);
+        burn_design(token.id)
 
-        const tokens = nft_supply_for_owner(token.owner_id);
+        const tokens = nft_supply_for_owner(token.owner_id)
 
-        expect(tokens).toStrictEqual('1');
-        log(tokens);
+        expect(tokens).toStrictEqual('1')
+        log(tokens)
     })
 })
 

--- a/as/cNFT/assembly/mint.ts
+++ b/as/cNFT/assembly/mint.ts
@@ -1,4 +1,11 @@
-import { context, logging, storage, u128 } from 'near-sdk-as'
+import {
+    ContractPromiseBatch,
+    context,
+    logging,
+    storage,
+    u128,
+    env,
+} from 'near-sdk-as'
 import {
     assert_eq_attached_deposit,
     assert_mints_per_address,
@@ -42,10 +49,12 @@ export function mint(
 
     /** Make sure default perp royalty is included */
     assert(
-        token_royalty.split_between.has(contract_extra.mint_royalty.id) &&
-            token_royalty.split_between.get(contract_extra.mint_royalty.id) ==
-                contract_extra.mint_royalty.amount,
-        ''
+        !contract_extra.mint_royalty_id ||
+            (token_royalty.split_between.has(contract_extra.mint_royalty_id) &&
+                token_royalty.split_between.get(
+                    contract_extra.mint_royalty_id
+                ) == contract_extra.mint_royalty_amount),
+        'Default perpetual royalty needs to be included in minted token.'
     )
 
     let token = new Token()

--- a/as/cNFT/assembly/models/persistent_nft_contract_metadata.ts
+++ b/as/cNFT/assembly/models/persistent_nft_contract_metadata.ts
@@ -1,5 +1,6 @@
-import { storage, u128 } from 'near-sdk-as'
+import { storage } from 'near-sdk-as'
 import { ONE_NEAR } from '../../../utils'
+import { AccountId } from '../types'
 
 const NFT_SPEC = 'nft-1.0.0'
 const NFT_NAME = 'Nft'
@@ -26,6 +27,11 @@ export class NFTContractExtra {
     max_copies: u32
     default_max_len_payout: u32
     mints_per_address: u32
+    mint_payee_id: ''
+    mint_royalty: {
+        id: AccountId
+        amount: u32
+    }
 }
 
 export function defaultNFTContractMetadata(): NFTContractMetadata {
@@ -50,21 +56,33 @@ export function defaultNFTContractExtra(): NFTContractExtra {
         max_copies: 1024,
         default_max_len_payout: 20,
         mints_per_address: 1024,
+        mint_payee_id: '',
+        mint_royalty: {
+            id: '',
+            amount: 0,
+        },
     }
 }
 
 @nearBindgen
 export class PersistentNFTContractMetadata {
-    static STORAGE_KEY_STANDARD: string = "nft_contract_metadata_standard"
-    static STORAGE_KEY_EXTRA: string = "nft_contract_metadata_extra"
+    static STORAGE_KEY_STANDARD: string = 'nft_contract_metadata_standard'
+    static STORAGE_KEY_EXTRA: string = 'nft_contract_metadata_extra'
 
     update_standard(contract_metadata: NFTContractMetadata): void {
-        storage.set<NFTContractMetadata>(PersistentNFTContractMetadata.STORAGE_KEY_STANDARD, contract_metadata)
+        storage.set<NFTContractMetadata>(
+            PersistentNFTContractMetadata.STORAGE_KEY_STANDARD,
+            contract_metadata
+        )
     }
 
     update_extra(contract_extra: NFTContractExtra): void {
-        storage.set<NFTContractExtra>(PersistentNFTContractMetadata.STORAGE_KEY_EXTRA, contract_extra)
+        storage.set<NFTContractExtra>(
+            PersistentNFTContractMetadata.STORAGE_KEY_EXTRA,
+            contract_extra
+        )
     }
 }
 
-export const persistent_nft_contract_metadata = new PersistentNFTContractMetadata()
+export const persistent_nft_contract_metadata =
+    new PersistentNFTContractMetadata()

--- a/as/cNFT/assembly/models/persistent_nft_contract_metadata.ts
+++ b/as/cNFT/assembly/models/persistent_nft_contract_metadata.ts
@@ -27,11 +27,9 @@ export class NFTContractExtra {
     max_copies: u32
     default_max_len_payout: u32
     mints_per_address: u32
-    mint_payee_id: ''
-    mint_royalty: {
-        id: AccountId
-        amount: u32
-    }
+    mint_payee_id: AccountId
+    mint_royalty_id: AccountId
+    mint_royalty_amount: u32
 }
 
 export function defaultNFTContractMetadata(): NFTContractMetadata {
@@ -57,10 +55,8 @@ export function defaultNFTContractExtra(): NFTContractExtra {
         default_max_len_payout: 20,
         mints_per_address: 1024,
         mint_payee_id: '',
-        mint_royalty: {
-            id: '',
-            amount: 0,
-        },
+        mint_royalty_id: '',
+        mint_royalty_amount: 0,
     }
 }
 

--- a/as/cNFT/assembly/utils/asserts.ts
+++ b/as/cNFT/assembly/utils/asserts.ts
@@ -28,11 +28,20 @@ export function assert_token_exists(token_id: TokenId): void {
     assert(persistent_tokens.has(token_id), "Token doesn't exist")
 }
 
-export function assert_eq_token_owner(predecessor: AccountId, owner_id: AccountId): void {
-    assert(predecessor == owner_id, "You must own token")
+export function assert_eq_token_owner(
+    predecessor: AccountId,
+    owner_id: AccountId
+): void {
+    assert(predecessor == owner_id, 'You must own token')
 }
 
-export function assert_mints_per_address(mints_per_address: u32, address: AccountId): void {
+export function assert_mints_per_address(
+    mints_per_address: u32,
+    address: AccountId
+): void {
     const owner_supply = parseInt(persistent_tokens.supply_for_owner(address))
-    assert(owner_supply < mints_per_address, "Limited to " + mints_per_address.toString() + " mints per owner")
+    assert(
+        owner_supply < mints_per_address,
+        'Limited to ' + mints_per_address.toString() + ' mints per owner'
+    )
 }

--- a/tests/cNFT.js
+++ b/tests/cNFT.js
@@ -147,6 +147,9 @@ const CONTRACT_EXTRA = {
     max_copies: 100,
     default_max_len_payout: 20,
     mints_per_address: 50,
+    mint_payee_id: 'jenny.test.near',
+    mint_royalty_id: 'jenny.test.near',
+    mint_royalty_amount: 10,
 }
 
 const TOKEN_ROYALTY = {


### PR DESCRIPTION
Add a promise payment to `payee_id` which is the account that receives mint price collector pays.
Add a default royalty percentage and `account_id` that are the default perpetual royalties applied to all tokens minted even after secondary sales (it's gonna be there forever). Add assert for it on minting.