### PR TITLE
Implemented approval (partially) system

### DIFF
--- a/as/cNFT/assembly/approval.ts
+++ b/as/cNFT/assembly/approval.ts
@@ -1,0 +1,78 @@
+import { TokenId } from "./types";
+import { AccountId } from "../../utils";
+import { assert_token_exists } from "./utils/asserts";
+import { persistent_tokens } from "./models/persistent_tokens";
+
+
+/**
+ * Check if the given account ID is approved to perform a transfer behalf of the owner of the particular token
+ *
+ * **Basic usage example:**
+ *
+ * Assume we need to check that a user with account id = `alice.test.near`, is approved to perform the transfer for a token with the token id = `jenny911038` and owner_Id = `jenny.test.near`,,
+ *
+ * ```
+ * const is_approved = nft_is_approved("jenny911038", "alice.test.near" ,1);
+ * console.log(is_approved); // true | false
+ * ```
+ *
+ * @param token_id ID of the token
+ * @param approved_account_id ID of the account that need check whether it is approved or not for the given token
+ * @param approval_id Approval ID number for the given `approved_account_id`
+ * @return Whether the account is approved or not
+ */
+@nearBindgen
+export function nft_is_approved(
+    token_id: TokenId,
+    approved_account_id: AccountId,
+    approval_id: string | null = null
+): boolean {
+
+    return internal_nft_is_approved(
+        token_id,
+        approved_account_id,
+        approval_id
+    )
+}
+
+
+/**
+ * Check if the given account ID is approved to perform a transfer behalf of the owner of the particular token
+ *
+ * **Note:** This is used as an internal function.
+ *
+ * **Basic usage example:**
+ *
+ * Assume we need to check that a user with account id = `alice.test.near`, is approved to perform the transfer for a token with the token id = `jenny911038` and owner_Id = `jenny.test.near`,,
+ *
+ * ```
+ * const is_approved = internal_nft_is_approved("jenny911038", "alice.test.near" ,1);
+ * console.log(is_approved); // true | false
+ * ```
+ *
+ * @param token_id ID of the token
+ * @param approved_account_id ID of the account that need check whether it is approved or not for the given token
+ * @param approval_id Approval ID number for the given `approved_account_id`
+ * @return Whether the account is approved or not
+ */
+export function internal_nft_is_approved(
+    token_id: TokenId,
+    approved_account_id: AccountId,
+    approval_id: string | null = null
+): boolean {
+
+    assert_token_exists(token_id);
+
+    let token = persistent_tokens.get(token_id)
+
+    const approval = token.approvals.has(approved_account_id)
+
+    if (approval) {
+        if (approval_id) {
+            const approvalId = token.approvals.get(approved_account_id)
+            return approvalId == parseInt(approval_id)
+        }
+        return true
+    }
+    return false
+}

--- a/as/cNFT/assembly/core.ts
+++ b/as/cNFT/assembly/core.ts
@@ -162,6 +162,39 @@ export function nft_is_approved(
     approval_id: string | null = null
 ): boolean {
 
+    return internal_nft_is_approved(
+            token_id,
+            approved_account_id,
+            approval_id
+        )
+}
+
+
+/**
+ * Check if the given account ID is approved to perform a transfer behalf of the owner of the particular token
+ *
+ * **Note:** This is used as an internal function.
+ *
+ * **Basic usage example:**
+ *
+ * Assume we need to check that a user with account id = `alice.test.near`, is approved to perform the transfer for a token with the token id = `jenny911038` and owner_Id = `jenny.test.near`,,
+ *
+ * ```
+ * const is_approved = internal_nft_is_approved("jenny911038", "alice.test.near" ,1);
+ * console.log(is_approved); // true | false
+ * ```
+ *
+ * @param token_id ID of the token
+ * @param approved_account_id ID of the account that need check whether it is approved or not for the given token
+ * @param approval_id Approval ID number for the given `approved_account_id`
+ * @return Whether the account is approved or not
+ */
+export function internal_nft_is_approved(
+    token_id: TokenId,
+    approved_account_id: AccountId,
+    approval_id: string | null = null
+): boolean {
+
     assert_token_exists(token_id);
 
     let token = persistent_tokens.get(token_id)

--- a/as/cNFT/assembly/core.ts
+++ b/as/cNFT/assembly/core.ts
@@ -4,7 +4,8 @@ import { Token, persistent_tokens } from './models/persistent_tokens'
 import { persistent_tokens_metadata } from './models/persistent_tokens_metadata'
 import { NftEventLogData, NftTransferLog, NftBurnLog } from './models/log'
 import { logging, context } from 'near-sdk-as'
-import {assert_one_yocto, assert_eq_token_owner, assert_not_paused, assert_token_exists} from './utils/asserts'
+import {assert_one_yocto, assert_not_paused } from './utils/asserts'
+import { internal_nft_is_approved } from "./approval";
 
 
 /**
@@ -137,81 +138,4 @@ export function burn_design(token_id: TokenId): void {
 
     const log = new NftEventLogData<NftBurnLog>('nft_burn', [burn_log]);
     logging.log(log);
-}
-
-
-
-/**
- * Check if the given account ID is approved to perform a transfer behalf of the owner of the particular token
- *
- * **Basic usage example:**
- *
- * Assume we need to check that a user with account id = `alice.test.near`, is approved to perform the transfer for a token with the token id = `jenny911038` and owner_Id = `jenny.test.near`,,
- *
- * ```
- * const is_approved = nft_is_approved("jenny911038", "alice.test.near" ,1);
- * console.log(is_approved); // true | false
- * ```
- *
- * @param token_id ID of the token
- * @param approved_account_id ID of the account that need check whether it is approved or not for the given token
- * @param approval_id Approval ID number for the given `approved_account_id`
- * @return Whether the account is approved or not
- */
-@nearBindgen
-export function nft_is_approved(
-    token_id: TokenId,
-    approved_account_id: AccountId,
-    approval_id: string | null = null
-): boolean {
-
-    return internal_nft_is_approved(
-            token_id,
-            approved_account_id,
-            approval_id
-        )
-}
-
-
-/**
- * Check if the given account ID is approved to perform a transfer behalf of the owner of the particular token
- *
- * **Note:** This is used as an internal function.
- *
- * **Basic usage example:**
- *
- * Assume we need to check that a user with account id = `alice.test.near`, is approved to perform the transfer for a token with the token id = `jenny911038` and owner_Id = `jenny.test.near`,,
- *
- * ```
- * const is_approved = internal_nft_is_approved("jenny911038", "alice.test.near" ,1);
- * console.log(is_approved); // true | false
- * ```
- *
- * @param token_id ID of the token
- * @param approved_account_id ID of the account that need check whether it is approved or not for the given token
- * @param approval_id Approval ID number for the given `approved_account_id`
- * @return Whether the account is approved or not
- */
-export function internal_nft_is_approved(
-    token_id: TokenId,
-    approved_account_id: AccountId,
-    approval_id: string | null = null
-): boolean {
-
-    assert_token_exists(token_id);
-
-    let token = persistent_tokens.get(token_id)
-
-    assert(token.owner_id != approved_account_id, "Owner does not need any approval to perform transactions for the token")
-
-    const approval = token.approvals.has(approved_account_id)
-
-    if (approval) {
-        if (approval_id) {
-            const approvalId = token.approvals.get(approved_account_id)
-            return approvalId == parseInt(approval_id)
-        }
-        return true
-    }
-    return false
 }

--- a/as/cNFT/assembly/core.ts
+++ b/as/cNFT/assembly/core.ts
@@ -5,7 +5,6 @@ import { persistent_tokens_metadata } from './models/persistent_tokens_metadata'
 import { NftEventLogData, NftTransferLog, NftBurnLog } from './models/log'
 import { logging, context } from 'near-sdk-as'
 import {assert_one_yocto, assert_eq_token_owner, assert_not_paused, assert_token_exists} from './utils/asserts'
-import {designs} from "../../NFT/assembly/models";
 
 
 /**
@@ -62,8 +61,12 @@ export function nft_transfer(token_id: TokenId, receiver_id: AccountId): void {
     /* Getting stored token from tokenId */
     const token = persistent_tokens.get(token_id)
 
-    /* todo: change when adding approval management */
-    assert_eq_token_owner(context.predecessor, token.owner_id)
+    if(token.owner_id != context.predecessor){
+        assert(
+            internal_nft_is_approved(token_id, context.predecessor, "1" ),
+            "You don't have permission to perform this action"
+        )
+    }
     /* Assert owner is not receiver */
     assert(receiver_id != token.owner_id, "Bidder is already the owner")
 

--- a/as/cNFT/assembly/index.ts
+++ b/as/cNFT/assembly/index.ts
@@ -10,7 +10,7 @@ import { AccountId } from './types'
 
 export { mint } from './mint'
 
-export { nft_token, nft_transfer, burn_design } from './core'
+export { nft_token, nft_transfer, burn_design, nft_is_approved } from './core'
 
 export {
     nft_supply_for_owner,

--- a/as/cNFT/assembly/index.ts
+++ b/as/cNFT/assembly/index.ts
@@ -10,7 +10,7 @@ import { AccountId } from './types'
 
 export { mint } from './mint'
 
-export { nft_token, nft_transfer, burn_design, nft_is_approved } from './core'
+export { nft_token, nft_transfer, burn_design } from './core'
 
 export {
     nft_supply_for_owner,
@@ -28,6 +28,8 @@ export {
 } from './market'
 
 export { nft_metadata, nft_metadata_extra } from './metadata'
+
+export { nft_is_approved } from  './approval'
 
 
 

--- a/as/cNFT/assembly/market.ts
+++ b/as/cNFT/assembly/market.ts
@@ -197,13 +197,8 @@ export function accept_bid(tokenId: string, bidder: string): void {
 
     const token = persistent_tokens.get(tokenId)
 
-    if(token.owner_id != context.predecessor){
-
-        assert(
-            internal_nft_is_approved(tokenId, context.predecessor, "1" ),
-            "You don't have permission to perform this action"
-        )
-    }
+    /* todo: change when adding approval management */
+    assert_eq_token_owner(context.predecessor, token.owner_id)
 
 
     const bid = bids.get(bidder)

--- a/as/cNFT/assembly/market.ts
+++ b/as/cNFT/assembly/market.ts
@@ -7,7 +7,6 @@ import { persistent_tokens_royalty } from './models/persistent_tokens_royalty'
 import { persistent_tokens } from './models/persistent_tokens'
 import { XCC_GAS } from '../../utils'
 import { assert_eq_attached_deposit, assert_one_yocto, assert_token_exists, assert_eq_token_owner, assert_not_paused } from './utils/asserts'
-import {internal_nft_is_approved, nft_is_approved} from "./core";
 
 class NftTransferArgs {
     token_id: string

--- a/as/cNFT/assembly/market.ts
+++ b/as/cNFT/assembly/market.ts
@@ -7,6 +7,7 @@ import { persistent_tokens_royalty } from './models/persistent_tokens_royalty'
 import { persistent_tokens } from './models/persistent_tokens'
 import { XCC_GAS } from '../../utils'
 import { assert_eq_attached_deposit, assert_one_yocto, assert_token_exists, assert_eq_token_owner, assert_not_paused } from './utils/asserts'
+import {internal_nft_is_approved, nft_is_approved} from "./core";
 
 class NftTransferArgs {
     token_id: string
@@ -196,8 +197,14 @@ export function accept_bid(tokenId: string, bidder: string): void {
 
     const token = persistent_tokens.get(tokenId)
 
-    /* todo: change when adding approval management */
-    assert_eq_token_owner(context.predecessor, token.owner_id)
+    if(token.owner_id != context.predecessor){
+
+        assert(
+            internal_nft_is_approved(tokenId, context.predecessor, "1" ),
+            "You don't have permission to perform this action"
+        )
+    }
+
 
     const bid = bids.get(bidder)
     const tokenRoyalty = persistent_tokens_royalty.get(tokenId)

--- a/as/cNFT/assembly/mint.ts
+++ b/as/cNFT/assembly/mint.ts
@@ -101,6 +101,10 @@ export function mint(
     token.creator_id = context.sender
     token.owner_id = context.sender
 
+    token.approvals = new Map<string, number>();
+    token.approvals.set(context.contractName, 1)
+    token.next_approval_id = 1;
+
     persistent_tokens_metadata.add(tokenId, tokenMetadata)
 
     persistent_tokens.add(tokenId, token, context.sender)

--- a/as/cNFT/assembly/models/persistent_tokens.ts
+++ b/as/cNFT/assembly/models/persistent_tokens.ts
@@ -19,6 +19,12 @@ export class Token {
 
     /** Metadata object of the token that describes the token */
     metadata: TokenMetadata
+
+    /** ID of the accounts, that can approve a transfer behalf of the owner */
+    approvals: Map<string, number>
+
+    /** Number used for the next approval ID */
+    next_approval_id: number
 }
 
 @nearBindgen


### PR DESCRIPTION
Below issue came up while using `nft_is_approved` method inside `nft_transfer` function.
[Problem with @nearBindgen decorator](https://github.com/curaOS/contracts/issues/65)

So, had to use the internal function method to get rid of that error.