### PR TITLE
Estimate costs in workspace tests

### DIFF
--- a/near-workspaces/__tests__/market.ava.ts
+++ b/near-workspaces/__tests__/market.ava.ts
@@ -225,7 +225,7 @@ workspace.test(
 
 
 workspace.test(
-    'Should bid one one token',
+    'Should bid on one token',
     async (test, { contract, alice, john }) => {
         const { result: minted } = await call_mint(contract, alice)
 

--- a/near-workspaces/__tests__/mint.ava.ts
+++ b/near-workspaces/__tests__/mint.ava.ts
@@ -24,7 +24,7 @@ workspace.test(
     'Mint multiple tokens',
     async (test, { contract, root }) => {
         
-        const totalUsers = 2;
+        const totalUsers = 100;
         const amountPerUser = 1;
         
         const users = await createUsers(root, totalUsers);

--- a/near-workspaces/__tests__/mint.ava.ts
+++ b/near-workspaces/__tests__/mint.ava.ts
@@ -1,5 +1,5 @@
-import { NearAccount, Workspace } from 'near-workspaces-ava'
-import { CONTRACT_EXTRA, CONTRACT_METADATA } from '../utils/dummyData'
+import { BN, NEAR, NearAccount, Workspace } from 'near-workspaces-ava'
+import { CONTRACT_EXTRA, CONTRACT_METADATA, GAS_PER_1byte } from '../utils/dummyData'
 import {
     call_mint, view_nft_tokens, view_nft_total_supply,
 } from '../utils/functions'
@@ -21,20 +21,21 @@ const workspace = Workspace.init(async ({ root }) => ({
 
 
 workspace.test(
-    'Mint 100 tokens',
+    'Mint multiple tokens',
     async (test, { contract, root }) => {
-        const totalUsers = 100;
+        
+        const totalUsers = 2;
         const amountPerUser = 1;
-
+        
         const users = await createUsers(root, totalUsers);
         const expectedTotalSupply = amountPerUser * users.length;
+        
+        const storage_usage_before = (await contract.accountView()).storage_usage
 
         await mintTokens(contract, users, amountPerUser)
 
         const { result: totalSupply } = await view_nft_total_supply(contract)
         test.assert(parseInt(totalSupply) == expectedTotalSupply)
-
-        test.log(`Minted ${expectedTotalSupply} tokens for a total of ${totalUsers} users`)
 
         // find the maximum tokens that can be fetched without gas using `nft_tokens`
         for (let i = 1; i < expectedTotalSupply; i++) {
@@ -50,6 +51,16 @@ workspace.test(
                 break
             }
         }
+
+        const storage_usage_after = (await contract.accountView()).storage_usage
+        const storage_used = storage_usage_after - storage_usage_before;
+        const estimated_gas = new BN(GAS_PER_1byte).mul(new BN(storage_used))
+        test.log(`-----------------------------------------------------------------------------------------------
+Users: ${totalUsers}
+Minted: ${totalSupply}
+Bytes used: ${storage_used} bytes
+Estimated gas cost: ${NEAR.from(estimated_gas).toHuman()} or ${estimated_gas.toString()} yoctoNEAR
+-----------------------------------------------------------------------------------------------`)
     }
 )
 

--- a/near-workspaces/utils/dummyData.ts
+++ b/near-workspaces/utils/dummyData.ts
@@ -3,6 +3,7 @@ export const ONE_NEAR = '1000000000000000000000000'
 export const ONE_YOCTO = '1'
 export const CONTRACT_MINT_PRICE = ONE_NEAR
 export const CONTRACT_MINT_GAS = '300000000000000'
+export const GAS_PER_1byte = '10000000000000000000'
 
 // Utility
 export function randomString(length) {


### PR DESCRIPTION
close #104 

### Examples:
https://github.com/curaOS/contracts/runs/5438854849?check_suite_focus=true#step:5:29
```log
  ✔ market.ava.ts › Should bid one one token (15.7s)
    ℹ -----------------------------------------------------------------------------------------------
      Bytes used per 1 bid: 1029 bytes
      Estimated gas cost per 1 bid: 10.29 mN or 10290000000000000000000 yoctoNEAR

      Estimated bytes used per 1000 bid: 1029000 bytes
      Estimated gas cost per 1000 bid: 10.29 N or 10290000000000000000000000 yoctoNEAR
      -----------------------------------------------------------------------------------------------
```

https://github.com/curaOS/contracts/runs/5438854849?check_suite_focus=true#step:5:103
```log
  ✔ mint.ava.ts › Mint multiple tokens (4m 46.1s)
    ℹ -----------------------------------------------------------------------------------------------
      Users: 100
      Minted: 100
      Bytes used: 248283 bytes
      Estimated gas cost: 2.48283 N or 2482830000000000000000000 yoctoNEAR
      -----------------------------------------------------------------------------------------------
```