### PR TITLE
Add min_bid_amount in NFTExtraMetadata

### DIFF
--- a/as/cNFT/assembly/market.ts
+++ b/as/cNFT/assembly/market.ts
@@ -56,7 +56,7 @@ export function set_bid(tokenId: string, bid: Bid): Bid {
 
     let contract_extra = storage.getSome<NFTContractExtra>(PersistentNFTContractMetadata.STORAGE_KEY_EXTRA)
     assert(
-        u128.ge(bid.amount, u128.from(contract_extra.min_bid_amount)),
+        u128.ge(context.attachedDeposit, u128.from(contract_extra.min_bid_amount)),
         "Minimum bid is " +
         asNEAR(u128.from(contract_extra.min_bid_amount))
         + " NEAR"

--- a/as/cNFT/assembly/market.ts
+++ b/as/cNFT/assembly/market.ts
@@ -1,12 +1,16 @@
-import { context, ContractPromise, ContractPromiseBatch, env, logging, u128 } from 'near-sdk-as'
+import {context, ContractPromise, ContractPromiseBatch, env, logging, storage, u128} from 'near-sdk-as'
 import { Bid, BidsByBidder } from './models/market'
 import { persistent_market } from './models/persistent_market'
 import { NftEventLogData, NftBidLog, NftRemoveBidLog, NftAcceptBidLog } from './models/log'
 import { internal_nft_payout } from './royalty_payout'
 import { persistent_tokens_royalty } from './models/persistent_tokens_royalty'
 import { persistent_tokens } from './models/persistent_tokens'
-import { XCC_GAS } from '../../utils'
+import {asNEAR, ONE_NEAR, XCC_GAS} from '../../utils'
 import { assert_eq_attached_deposit, assert_one_yocto, assert_token_exists, assert_eq_token_owner, assert_not_paused } from './utils/asserts'
+import {
+    NFTContractExtra,
+    PersistentNFTContractMetadata
+} from "./models/persistent_nft_contract_metadata";
 
 class NftTransferArgs {
     token_id: string
@@ -49,6 +53,14 @@ export function set_bid(tokenId: string, bid: Bid): Bid {
     assert(bid.amount > u128.Zero, "Bid can't be zero")
     assert_eq_attached_deposit(bid.amount)
     assert_token_exists(tokenId)
+
+    let contract_extra = storage.getSome<NFTContractExtra>(PersistentNFTContractMetadata.STORAGE_KEY_EXTRA)
+    assert(
+        u128.ge(bid.amount, u128.from(contract_extra.min_bid_amount)),
+        "Minimum bid is " +
+        asNEAR(u128.from(contract_extra.min_bid_amount))
+        + " NEAR"
+    )
 
     // Refund previous bid If user has one
     if(persistent_market.has(tokenId)){

--- a/as/cNFT/assembly/models/persistent_nft_contract_metadata.ts
+++ b/as/cNFT/assembly/models/persistent_nft_contract_metadata.ts
@@ -110,7 +110,7 @@ export function defaultNFTContractExtra(): NFTContractExtra {
         mint_payee_id: '',
         mint_royalty_id: '',
         mint_royalty_amount: 0,
-        min_bid_amount: u128.div(ONE_NEAR, u128.from(10)).toString()
+        min_bid_amount: '0'
     }
 }
 

--- a/as/cNFT/assembly/models/persistent_nft_contract_metadata.ts
+++ b/as/cNFT/assembly/models/persistent_nft_contract_metadata.ts
@@ -1,4 +1,4 @@
-import { storage } from 'near-sdk-as'
+import {storage, u128} from 'near-sdk-as'
 import { ONE_NEAR } from '../../../utils'
 import { AccountId } from '../types'
 
@@ -72,6 +72,9 @@ export class NFTContractExtra {
 
     /** Amount of royalty, in percentage, that is set on each minted token. */
     mint_royalty_amount: u32
+
+    /** Minimum amount of a bid that can be placed to a token in contract */
+    min_bid_amount: string
 }
 
 
@@ -107,6 +110,7 @@ export function defaultNFTContractExtra(): NFTContractExtra {
         mint_payee_id: '',
         mint_royalty_id: '',
         mint_royalty_amount: 0,
+        min_bid_amount: u128.div(ONE_NEAR, u128.from(10)).toString()
     }
 }
 

--- a/near-workspaces/__tests__/market.ava.ts
+++ b/near-workspaces/__tests__/market.ava.ts
@@ -24,7 +24,7 @@ const workspace = Workspace.init(async ({ root }) => ({
                 contract_metadata: CONTRACT_METADATA,
                 contract_extra: {
                     ...CONTRACT_EXTRA,
-                    ...{ mints_per_address: 2, max_copies: 3 },
+                    ...{ mints_per_address: 2, max_copies: 3, min_bid_amount: NEAR.parse("0.1N").toString() },
                 },
             },
         }

--- a/near-workspaces/__tests__/market.ava.ts
+++ b/near-workspaces/__tests__/market.ava.ts
@@ -77,18 +77,14 @@ workspace.test(
         //     })
         // })
         // log(`✔  John failed to bid using alice account\n`)
-
-        /**
-         *  @todo fix in contract
-         *  https://github.com/curaOS/contracts/issues/94
-         * */
-        // await test.throwsAsync(async () => {
-        //     await call_set_bid(contract, john, {
-        //         tokenId: minted.id,
-        //         bid: {... john_example_bid, amount: NEAR.parse("0.05N") }
-        //     })
-        // })
-        // log(`✔  John failed to bid less than `min_bid_amount`\n`)
+        
+        await test.throwsAsync(async () => {
+            await call_set_bid(contract, john, {
+                tokenId: minted.id,
+                bid: {... john_example_bid, amount: NEAR.parse("0.05N") }
+            })
+        })
+        test.log(`✔  John failed to bid less than min_bid_amount\n`)
 
         await test.throwsAsync(async () => {
             await call_set_bid(contract, john, {

--- a/near-workspaces/utils/dummyData.ts
+++ b/near-workspaces/utils/dummyData.ts
@@ -1,7 +1,9 @@
 // Amounts
 export const ONE_NEAR = '1000000000000000000000000'
+export const ONE_CENT_NEAR = '100000000000000000000000'
 export const ONE_YOCTO = '1'
 export const CONTRACT_MINT_PRICE = ONE_NEAR
+export const CONTRACT_MIN_BID_AMOUNT = ONE_CENT_NEAR
 export const CONTRACT_MINT_GAS = '300000000000000'
 
 // Utility
@@ -45,6 +47,7 @@ export const CONTRACT_EXTRA = {
     mint_payee_id: 'jenny.test.near',
     mint_royalty_id: 'jenny.test.near',
     mint_royalty_amount: 10,
+    min_bid_amount: CONTRACT_MIN_BID_AMOUNT
 }
 
 export function get_random_token_metadata() {

--- a/near-workspaces/utils/dummyData.ts
+++ b/near-workspaces/utils/dummyData.ts
@@ -1,9 +1,7 @@
 // Amounts
 export const ONE_NEAR = '1000000000000000000000000'
-export const ONE_CENT_NEAR = '100000000000000000000000'
 export const ONE_YOCTO = '1'
 export const CONTRACT_MINT_PRICE = ONE_NEAR
-export const CONTRACT_MIN_BID_AMOUNT = ONE_CENT_NEAR
 export const CONTRACT_MINT_GAS = '300000000000000'
 
 // Utility
@@ -47,7 +45,7 @@ export const CONTRACT_EXTRA = {
     mint_payee_id: 'jenny.test.near',
     mint_royalty_id: 'jenny.test.near',
     mint_royalty_amount: 10,
-    min_bid_amount: CONTRACT_MIN_BID_AMOUNT
+    min_bid_amount: '0',
 }
 
 export function get_random_token_metadata() {

--- a/tests/cNFT.js
+++ b/tests/cNFT.js
@@ -127,6 +127,7 @@ const CONTRACT_TOKENS_GAS =
     nearAPI.utils.format.parseNearAmount('0.00000000030') // 1000 Tgas
 const ONE_NEAR = nearAPI.utils.format.parseNearAmount('1')
 const CONTRACT_MINT_PRICE = ONE_NEAR
+const MINIMUM_BID_PRICE = nearAPI.utils.format.parseNearAmount('0.1')
 
 // Example data
 const CONTRACT_METADATA = {
@@ -150,6 +151,7 @@ const CONTRACT_EXTRA = {
     mint_payee_id: 'jenny.test.near',
     mint_royalty_id: 'jenny.test.near',
     mint_royalty_amount: 10,
+    min_bid_amount: MINIMUM_BID_PRICE
 }
 
 const TOKEN_ROYALTY = {


### PR DESCRIPTION
- Added `0` as the default `min_bid_amount` for contract extra metadata.